### PR TITLE
Use CMake install instead of manually copying header, remove mock binary

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,15 +1,10 @@
-cmake ${CMAKE_ARGS} 	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_INSTALL_PREFIX=$PREFIX \
-	-DCMAKE_PREFIX_PATH=$PREFIX \
-	-DBUILD_DOCS=OFF \
-	-DCMAKE_INSTALL_LIBDIR=$PREFIX/lib
+cmake ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DCMAKE_PREFIX_PATH=$PREFIX \
+  -DBUILD_DOCS=OFF \
+  -DCMAKE_INSTALL_LIBDIR=$PREFIX/lib
 
-make -j$CPU_COUNT
-
-mkdir -p $PREFIX/bin
-mkdir -p $PREFIX/include/dlpack
-cp include/dlpack/*.h $PREFIX/include/dlpack/.
-cp bin/mock $PREFIX/bin/.
-
-
+cmake --build . --parallel $CPU_COUNT
+cmake --install .
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: cf965c26a5430ba4cc53d61963f288edddcd77443aa4c85ce722aaf1e2f29513
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -24,7 +24,7 @@ test:
   commands:
     - test -d ${PREFIX}/include/dlpack  # [unix]
     - test -f ${PREFIX}/include/dlpack/dlpack.h  # [unix]
-    - test -f ${PREFIX}/bin/mock  # [unix]
+    - test -d ${PREFIX}/lib/cmake/dlpack  # [unix]
 
 about:
   home: https://github.com/dmlc/dlpack


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This should allow downstream packages to use CMake `find_package(dlpack)` if desired. Also removes the mock binary from the output since it doesn't serve any purpose other than ensuring that the header can compile successfully, which we'll still get testing of here since it will still build the mock executable.